### PR TITLE
ci: add release and publish actions

### DIFF
--- a/.github/workflows/npm_upload.yml
+++ b/.github/workflows/npm_upload.yml
@@ -1,0 +1,18 @@
+name: Publish to NPM
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  Publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          access: public
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bump version
+        run: |
+          npm run release -- --release-as ${{ env.RELEASE_VERSION }} --no-verify --skip.changelog
+
+      - name: Push tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email actions@github.com
+          git push --follow-tags origin main
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          tag: v${{ env.RELEASE_VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds two Github Actions to facilitate continuous releases.

1. The `Release` workflow is manually triggered with a `version` input. This bumps the package version, commits the change, and pushes the changes and new tag.
2. The `Publish` workflow is triggered by the tag push from (1), and publishes the package to NPM.

Note: The tag push also triggers the `Deploy` workflow which deploys to Cloudfront.
