### PR TITLE
fix(#7): downgrade getAllTransfers error to warning

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -407,7 +407,7 @@ const Connect = function Connect (this: types.ConnectClientType, options?: types
         if (callbacks.error) callbacks.error(err);
       });
     } else {
-      throw new Error('getAllTransfers: No method is available for getting all transfers');
+      Logger.warn('getAllTransfers: No method is available for getting all transfers');
     }
   }
   /**


### PR DESCRIPTION
`getAllTransfers()` is executed when a transfer event listener is created via `addEventListener()`. The error can be thrown during a normal initialization sequence or even during upgrade scenarios. It is a bit too noisy so we will downgrade to a warning instead.