### PR TITLE
chore: add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+Aspera-Release@wwpdl.vnet.ibm.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,14 @@ The Aspera Connect SDK for JavaScript is an **open source** project at IBM. We p
 
 We value all of our community members, and thus want to foster a positive contributing environment. Please take a look at our [code of conduct](./CODE_OF_CONDUCT.md) before beginning any work.
 
+## Who can contribute?
+
+Anyone! The one and only requirement is you'll need a [public GitHub account](https://github.com/join), as all our assets live on GitHub.
+
+- **Bug Reports:** Found an issue? Feel free to [open a bug report](https://github.com/IBM/aspera-connect-sdk-js/issues) to notify us of a potential issue, but please include as much detailed information as possible, such as the version of the Aspera Connect SDK, configuration options, browser version, etc.
+- **Development:** If coding is your thing, you can help us by contributing bug fixes or new features.
+- **Documentation:** Our documentation is just as important as the code itself, and anyone is welcome contribute to our documentation to make sure it stays correct and up-to-date.
+
 ## Prerequisites
 
 Before contributing, check out the [README](../README.md#prerequisites) to make sure you have the necessary tools installed.
@@ -137,10 +145,3 @@ Stay up to date with the activity in your pull request. Maintainers from the Asp
 When you need to make a change, use the same method detailed above except you no longer need to run `git push -u origin { YOUR_BRANCH_NAME }` just `git push`.
 
 Once all revisions to your pull request are complete, one of the maintainers will squash and merge your commits for you.
-
-## Who can contribute?
-
-Anyone! The one and only requirement is you'll need a [public GitHub account](https://github.com/join), as all our assets live on GitHub.
-
-- **Development:** If coding is your thing, you can help us by contributing bug fixes or new features.
-- **Documentation:** Our documentation is just as important as the code itself, and anyone is welcome contribute to    our documentation to make sure it stays correct and up-to-date.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing
+
+First off, thank you for your interest!
+
+The Aspera Connect SDK for JavaScript is an **open source** project at IBM. We pride ourselves in open and inclusive development. If you're wondering more about our contribution process, you're in the right place.
+
+## Code of conduct
+
+We value all of our community members, and thus want to foster a positive contributing environment. Please take a look at our [code of conduct](./CODE_OF_CONDUCT.md) before beginning any work.
+
+## Prerequisites
+
+Before contributing, check out the [README](../README.md#prerequisites) to make sure you have the necessary tools installed.
+
+## Start contributing
+
+### 1. Fork the repo:
+
+Go to the [Aspera Connect SDK](https://github.com/IBM/aspera-connect-sdk-js) repository in GitHub and click the `Fork` button in the top-right corner. This will create a copy repo of the Aspera Connect SDK associated with your account.
+
+### 2. Clone your fork:
+
+```sh
+git clone git@github.com:[your_github_username]/aspera-connect-sdk-js.git
+cd aspera-connect-sdk-js
+```
+
+See [GitHub docs](https://help.github.com/articles/fork-a-repo/) for more
+details.
+
+### 3. Add upstream remotes
+
+When you clone your forked repo, running `git remote -v` will show that the
+`origin` is pointing to your forked repo by default.
+
+Now you need to add the `IBM/aspera-connect-sdk-js` repo as your upstream
+remote branch:
+
+```sh
+# Add the upstream remote to your repo
+git remote add upstream git@github.com:IBM/aspera-connect-sdk-js.git
+
+# Verify the remote was added
+git remote -v
+```
+
+Your terminal should output something like this:
+
+```sh
+origin  [your forked repo] (fetch)
+origin  [your forked repo] (push)
+upstream    git@github.com:IBM/aspera-connect-sdk-js.git (fetch)
+upstream    git@github.com:IBM/aspera-connect-sdk-js.git (push)
+```
+
+### 4. Work in a branch
+
+When contributing, your work should always be done in a branch off of your repo, this is also how you will submit your pull request when your work is done.
+
+To create a new branch, ensure you are in your forked branch in your terminal
+and run:
+
+```sh
+git pull origin main
+git checkout -b {your-branch-name}
+```
+
+### 5. Build
+
+From the root directory of your fork, run:
+
+```sh
+# To install the project's dependencies
+npm install
+
+# To build the project:
+npm run build
+```
+
+For coding style, we generally follow the [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript).
+
+### 6. Test your code
+
+If you're contributing, test your changes by running our test commands:
+
+```sh
+npm run test
+```
+
+Also, always make sure to run our linter command:
+
+```sh
+npm run lint
+```
+
+### 7. Make a pull request
+
+**Note:** Before you make a pull request, [search](https://github.com/IBM/aspera-connect-sdk-js/issues) the issues to see if a similar issue has already been submitted. If a similar issue has been submitted, assign yourself or ask to be assigned to the issue by posting a comment. If the issue does not exist, please make a new issue. Issues give us context about what you are contributing and expedite the process to getting your contributions merged.
+
+When you're at a good stopping place and you're ready for feedback from other
+contributors and maintainers, **push your commits to your fork**:
+
+To do so, go to your terminal and run:
+
+```sh
+git add -A
+git commit -m "YOUR  COMMIT MESSAGE HERE"
+```
+
+#### Commit tip
+
+> **Writing commit messages**
+>
+> - `<type>` indicates the type of commit that's being made. This can be:
+>   `feat`, `fix`, `perf`, `docs`, `chore`, `style`, `refactor`
+> - `<scope>` The scope could be anything specifying place of the commit change
+>   or the thing(s) that changed.
+
+After your changes are committed, run:
+
+```sh
+git push -u origin { YOUR_BRANCH_NAME }
+```
+
+In your browser, navigate to
+[IBM/aspera-connect-sdk-js](https://github.com/IBM/aspera-connect-sdk-js)
+and click the button that reads `Compare & pull request`
+
+Write a title and description then click `Create pull request`
+
+- [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)
+
+### 9. Updating a pull request
+
+Stay up to date with the activity in your pull request. Maintainers from the Aspera Connect SDK team will be reviewing your work and making comments, asking questions and suggesting changes to be made before they merge your code.
+
+When you need to make a change, use the same method detailed above except you no longer need to run `git push -u origin { YOUR_BRANCH_NAME }` just `git push`.
+
+Once all revisions to your pull request are complete, one of the maintainers will squash and merge your commits for you.
+
+## Who can contribute?
+
+Anyone! The one and only requirement is you'll need a [public GitHub account](https://github.com/join), as all our assets live on GitHub.
+
+- **Development:** If coding is your thing, you can help us by contributing bug fixes or new features.
+- **Documentation:** Our documentation is just as important as the code itself, and anyone is welcome contribute to    our documentation to make sure it stays correct and up-to-date.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Refer to [MIGRATION](MIGRATION.md) to see the required changes when updating you
 ## Development
 
 ### Prerequisites
-* NodeJS 12+
+* [Node.js](https://nodejs.org/en/download/) v12+
+  - If you are on macOS, we recommend installing Node.js via a package manager such as [nvm](https://github.com/nvm-sh/nvm).
+* Git
 
 ### Build
 
@@ -79,6 +81,10 @@ $ cd aspera-connect-sdk-js
 $ npm install
 $ npm run build
 ```
+
+## Contributing
+
+We're always looking for contributors to help us fix bugs, build new features, or help us improve the project documentation. If you're interested, definitely check out our [Contributing Guide](/.github/CONTRIBUTING.md).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Part of the process in achieving the OpenSSF Best Practices badge includes having certain things like contribution guidelines, etc. So adding both contribution and code of conduct files here to be more in alignment with standard best practices for open-source projects on GitHub.

The code of conduct is taken from the GitHub template and the contribution guide follows both the IBM Carbon and Atom open-source projects.