### PR TITLE
docs: how to locally host installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,33 @@ $ npm install
 $ npm run build
 ```
 
+## Locally hosting the Connect desktop installers
+Rather than having users download Connect from Cloudfront, it is possible to host the installers locally. This is particularly useful if your server is running in an offline environment (i.e. users will not have access to Cloudfront) or if you would simply prefer users download Connect from your server.
+
+To download the `connect-deployer` Docker image:
+
+```shell
+$ docker pull icr.io/ibmaspera/connect-deployer:latest
+```
+
+Version tags are also available starting from Connect 4.2.2 (ex: `docker pull icr.io/ibmaspera/connect-deployer:4.2.2`).
+
+#### To host the installers on a basic web server:
+
+```shell
+$ docker run -it --rm -d -p 8080:80 icr.io/ibmaspera/connect-deployer:latest
+```
+
+With the above command, the Connect installers will be available over `http://127.0.0.1:8080/aspera/connect`. To configure the Connect SDK to serve the Connect installers from this URL you must update [`sdkLocation`](https://ibm.github.io/aspera-connect-sdk-js/AW4.ConnectInstaller.html#ConnectInstaller) to the above URL.
+
+#### To host the installers over a secure web server:
+
+```shell
+$ docker run -it --rm -d -p 8443:443  -v /path/to/your/ssl/certs:/etc/ssl/certs icr.io/ibmaspera/connect-deployer:latest
+```
+
+Note: The server certificate and private key must be named `cert.pem` and `key.pem`, respectively.
+
 ## Contributing
 
 We're always looking for contributors to help us fix bugs, build new features, or help us improve the project documentation. If you're interested, definitely check out our [Contributing Guide](/.github/CONTRIBUTING.md).


### PR DESCRIPTION
Adds a section to the `README.md` that details how to locally host the Connect installers via the `connect-deployer` Docker image.