### PR TITLE
feat: disable prevent default option

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -975,7 +975,10 @@ const Connect = function Connect (this: types.ConnectClientType, options?: types
         evt.stopPropagation();
       }
 
-      evt.preventDefault();
+      if (!options.disablePreventDefault) {
+        evt.preventDefault();
+      }
+
       // Prepare request and create a valid JSON object to be serialized
       const filesDropped = evt.dataTransfer.files;
       const data: any = {};

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -212,6 +212,11 @@ export interface DragDropOptions {
   dragLeave?: boolean;
   drop?: boolean;
   allowPropagation?: boolean;
+  /**
+   * If `true`, the Connect SDK will not prevent the default action on drag/drop events. Instead, the client
+   * will be responsible for preventing the default action. For most use cases, this option is not needed.
+   */
+  disablePreventDefault?: boolean;
 }
 
 interface DragDropEvent {

--- a/test/pages/connect/index.html
+++ b/test/pages/connect/index.html
@@ -633,7 +633,7 @@ li {
     tests.setDragDropTargets = function() {
         var options = formInputToObj(
             {},
-            ["dragEnter", "dragOver", "dragLeave", "drop", "allowPropagation"]);
+            ["dragEnter", "dragOver", "dragLeave", "drop", "allowPropagation", "disablePreventDefault"]);
         log("Invoking SetDragDropTargets.", options);
         log("showSaveFileDialog SetDragDropTargets.", plugin.setDragDropTargets(
             ".drop-target",
@@ -2458,6 +2458,19 @@ li {
                     </label>
                     <label>
                         <input name="input_allowPropagation"
+                            type="radio" value="false" />
+                        false
+                    </label>
+                </li>
+                <li>
+                    <label>disablePreventDefault</label>
+                    <label>
+                        <input name="input_disablePreventDefault"
+                            type="radio" value="true" />
+                        true
+                    </label>
+                    <label>
+                        <input name="input_disablePreventDefault"
                             type="radio" value="false" />
                         false
                     </label>


### PR DESCRIPTION
Closes #52.

Fixes the issue where dropping a file onto an input element is blocked since the default handling has been prevented by the Connect SDK.

When set to `true`, this option results in the Connect SDK not calling `evt.preventDefault()` on the drop event. When not set or set to `false`, `evt.preventDefault` is called.