### PR TITLE
GetDroppedFiles implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,16 @@
 # Dependencies
-node_modules/
+node_modules
 
 # Builds
-/dist
-build/
+dist
+build
 
 # Installer directory
-/imports
+imports
 
 # Misc
 .DS_Store
-/.vscode
+.vscode
 
 # JetBrans IDE
 .idea

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -219,6 +219,10 @@ export interface DragDropOptions {
   disablePreventDefault?: boolean;
 }
 
+export interface DragDropDataTransfer {
+  dataTransfer: { files: FileObject[] };
+}
+
 interface DragDropEvent {
   /** DOM Event object as implemented by the browser. */
   event: DragEvent;
@@ -462,6 +466,11 @@ export interface ConnectClientType {
     cssSelector: string,
     options: DragDropOptions,
     listener: DragDropListener
+  ): void | ConnectError;
+
+  getDroppedFiles (
+    data: DragDropDataTransfer,
+    callbacks: Callbacks<any>
   ): void | ConnectError;
 
   showAbout (callbacks: Callbacks<EmptyObject>): void;


### PR DESCRIPTION
### Requirement
Closes [#2177](https://github.ibm.com/Aspera/connect-app/issues/2177)

Add a `getDroppedFiles` method to the public interface that could be used by clients to get dropped files manually. Could be useful for cases like this where `setDragDropTargets` isn't used.

### Implementation

Added a new `getDroppedFiles` function to the public interface.