### PR TITLE
ci: update github release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
           git push --follow-tags origin main
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          generateReleaseNotes: true
-          tag: v${{ env.RELEASE_VERSION }}
+          generate_release_notes: true
+          tag_name: v${{ env.RELEASE_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Migrate to `softprops/action-gh-release` as the previous one is no longer allowed in the IBM GitHub organization.